### PR TITLE
fix width from float to int, as required by skimage.measure.profile_line

### DIFF
--- a/nep_fitting/core/handlers.py
+++ b/nep_fitting/core/handlers.py
@@ -89,7 +89,7 @@ class LineProfileHandler(BaseHandler):
         self.image = image_data
         self.image_name = image_name
         self.interpolation_order = interpolation_order
-        self._width = 1.0
+        self._width = 1
         if self.image is not None:
             self.mdh = NestedClassMDHandler(self.image.mdh)
         else:

--- a/nep_fitting/core/rois.py
+++ b/nep_fitting/core/rois.py
@@ -137,11 +137,11 @@ class LineProfile(BaseROI):
             being created from a previously saved profile
         """
         super(self.__class__, self).__init__(identifier=identifier, image_name=image_name)
-        self._r1 = r1
-        self._c1 = c1
-        self._r2 = r2
-        self._c2 = c2
-        self._slice = slice
+        self._r1 = int(r1) if r1 is not None else r1
+        self._c1 = int(c1) if c1 is not None else c1
+        self._r2 = int(r2) if r2 is not None else r2
+        self._c2 = int(c2) if c2 is not None else c2
+        self._slice = int(slice) if slice is not None else slice
         self._width = width
         self.set_profile(profile)
         self.set_distance(distance)

--- a/nep_fitting/core/rois.py
+++ b/nep_fitting/core/rois.py
@@ -107,7 +107,7 @@ class LineProfile(BaseROI):
     recarrays and saves each profile as a separate table in the same hdf file.
     """
     
-    def __init__(self, r1=None, c1=None, r2=None, c2=None, slice=0, width=1.0, identifier=None, image_name=None,
+    def __init__(self, r1=None, c1=None, r2=None, c2=None, slice=0, width=1, identifier=None, image_name=None,
                  profile=None, distance=None):
         """
 
@@ -141,8 +141,8 @@ class LineProfile(BaseROI):
         self._c1 = int(c1) if c1 is not None else c1
         self._r2 = int(r2) if r2 is not None else r2
         self._c2 = int(c2) if c2 is not None else c2
-        self._slice = int(slice) if slice is not None else slice
-        self._width = width
+        self._slice = int(slice)
+        self._width = int(width)
         self.set_profile(profile)
         self.set_distance(distance)
     

--- a/nep_fitting/dsviewer_modules/sted_psf_fitting.py
+++ b/nep_fitting/dsviewer_modules/sted_psf_fitting.py
@@ -108,10 +108,10 @@ class LineProfilesOverlay:
         h_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
         h_sizer.Add(wx.StaticText(pan, -1, 'Line width:'))
-        width_control = wx.TextCtrl(pan, -1, name='Line width',
-                                    value=str(self._line_profile_handler.get_line_profile_width()))
-        width_control.Bind(wx.EVT_KEY_UP, self._on_width_change)
-        h_sizer.Add(width_control, 1, wx.EXPAND, 0)
+        self.width_control = wx.TextCtrl(pan, -1, name='Line width',
+                                         value=str(self._line_profile_handler.get_line_profile_width()))
+        self.width_control.Bind(wx.EVT_KEY_UP, self._on_width_change)
+        h_sizer.Add(self.width_control, 1, wx.EXPAND, 0)
         h_sizer.Add(wx.StaticText(pan, -1, 'px'))
         v_sizer.Add(h_sizer, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 2)
 
@@ -274,13 +274,15 @@ class LineProfilesOverlay:
 
         value = event.EventObject.Value
         try:
-            float_value = float(value)
-            if float_value > 0.0:
-                self._line_profile_handler.set_line_profile_width(float_value)
+            # profile extraction takes an int, cast the GUI input and update the GUI to keep things in sync
+            value = int(float(value))
+            if value > 0:
+                self._line_profile_handler.set_line_profile_width(value)
+                self.width_control.SetValue(str(self._line_profile_handler.get_line_profile_width()))
+                self.width_control.Refresh()
                 self._refresh()
         except ValueError:
             pass
-        pass
 
     def _refresh(self, sender=None, **kwargs):
         """


### PR DESCRIPTION
fix to an issue on py26, numpy 1.18, scikit-image 0.15
```
Traceback (most recent call last):
  File "c:\users\pk466\code\python-microscopy\PYME\DSView\scrolledImagePanel.py", line 58, in OnPaint
    self.renderer(MemDC);
  File "c:\users\pk466\code\python-microscopy\PYME\DSView\arrayViewPanel.py", line 528, in DoPaint
    ovl(self, dc)
  File "c:\users\pk466\code\nep-fitting\nep_fitting\dsviewer_modules\sted_psf_fitting.py", line 232, in DrawOverlays
    for line_profile, visible in zip(self._line_profile_handler.get_line_profiles(),
  File "c:\users\pk466\code\nep-fitting\nep_fitting\core\handlers.py", line 256, in get_line_profiles
    self.calculate_profiles()
  File "c:\users\pk466\code\nep-fitting\nep_fitting\core\handlers.py", line 274, in calculate_profiles
    order=self.interpolation_order, linewidth=self._width))
  File "C:\Users\pk466\Miniconda3\lib\site-packages\skimage\measure\profile.py", line 60, in profile_line
    perp_lines = _line_profile_coordinates(src, dst, linewidth=linewidth)
  File "C:\Users\pk466\Miniconda3\lib\site-packages\skimage\measure\profile.py", line 115, in _line_profile_coordinates
    linewidth) for row_i in line_row])
  File "C:\Users\pk466\Miniconda3\lib\site-packages\skimage\measure\profile.py", line 115, in <listcomp>
    linewidth) for row_i in line_row])
  File "<__array_function__ internals>", line 6, in linspace
  File "C:\Users\pk466\Miniconda3\lib\site-packages\numpy\core\function_base.py", line 121, in linspace
    .format(type(num)))
TypeError: object of type <class 'float'> cannot be safely interpreted as an integer.
```