### PR TITLE
make saving more robust / increment version number / allow conda build on py3

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -117,7 +117,7 @@ requirements:
   # Package names should be any valid conda spec (see "Specifying versions
   # in requirements" below).
   run:
-    - python 2.7
+    - python
     - python-microscopy >=17.10.24
 
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: nep-fitting       # lower case name of package, may contain '-' but no spaces
-  version: "1.7"    # version of package. Should use the PEP-386 verlib
+  version: "1.8"    # version of package. Should use the PEP-386 verlib
                       # conventions. Note that YAML will interpret
                       # versions like 1.0 as floats, meaning that 1.0 will
                       # be the same as 1. To avoid this, always put the

--- a/nep_fitting/dsviewer_modules/sted_psf_fitting.py
+++ b/nep_fitting/dsviewer_modules/sted_psf_fitting.py
@@ -332,18 +332,18 @@ class LineProfilesOverlay:
             ensemble_params = e_res.dtype.names
             ensemble_results = {name: (e_res[name], res['ensemble_uncertainty'][0][name]) for name in ensemble_params}
 
-            fpath = fdialog.GetPath()
-
-            res.to_hdf(fpath, tablename='profile_fits') #table name changed to avoid conflicts with standard fit data
+            base_path = os.path.splitext(fdialog.GetPath())[0]
+            
+            res.to_hdf(base_path + '.hdf', tablename='profile_fits') #table name changed to avoid conflicts with standard fit data
 
             # plot individual profiles
             # fitter = profile_fitters.ensemble_fitters[fitting_module.fit_type](self._line_profile_handler)
             fitter = rec.modules[0].fitter  # TODO - move plot_results out from class so we don't have to hack like this
-            profile_dir = os.path.splitext(fpath)[0] + '/'
+            profile_dir = base_path + '/'
             os.mkdir(profile_dir)
             fitter.plot_results(profile_dir)
 
-            htmlfn = os.path.splitext(fpath)[0] + '.html'
+            htmlfn = base_path + '.html'
             
             context = {'ensemble_results' : ensemble_results,
                        'results' : res,
@@ -399,7 +399,7 @@ class LineProfilesOverlay:
                                 defaultDir=nameUtils.genShiftFieldDirectoryPath())
         succ = fdialog.ShowModal()
         if (succ == wx.ID_OK):
-            fpath = fdialog.GetPath()
+            fpath = os.path.splitext(fdialog.GetPath())[0] + '.html'
             reports.generate_and_save(fpath, context, template_name='ensemble_test.html')
 
             webbrowser.open('file://' + fpath, 2)
@@ -430,16 +430,16 @@ class LineProfilesOverlay:
                                 defaultDir=nameUtils.genShiftFieldDirectoryPath())  # , defaultFile=defFile)
         succ = fdialog.ShowModal()
         if (succ == wx.ID_OK):
-            fpath = fdialog.GetPath()
+            base_path = os.path.splitext(fdialog.GetPath())[0]
 
-            res.to_hdf(fpath, tablename='profile_fits')  # table name changed to avoid conflicts with standard fit data
+            res.to_hdf(base_path + '.hdf', tablename='profile_fits')  # table name changed to avoid conflicts with standard fit data
 
             fitter = rec.modules[0].fitter  # TODO - move plot_results out from class so we don't have to hack like this
-            profile_dir = os.path.splitext(fpath)[0] + '/'
+            profile_dir = base_path + '/'
             os.mkdir(profile_dir)
             fitter.plot_results(profile_dir)
 
-            htmlfn = os.path.splitext(fpath)[0] + '.html'
+            htmlfn = base_path + '.html'
 
             context = {'results': res,
                        'filename': self._dsviewer.image.filename,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 setup(name='nep_fitting',
-      version='1.7',
+      version='1.8',
       description='Nested-loop Ensemble PSF fitting',
       author='Andrew Barentine, Michael Graff, David Baddeley',
       author_email='andrew.barentine@yale.edu',


### PR DESCRIPTION
Currently, if you run one of the fits from the GUI and in the save results file dialog you don't type the extension on your own, the hdf file will get saved with no extension, which clobbers the subsequent `os.mkdirs` call trying to save the profiles. This PR fixes that by forcing the extension to hdf, increments the version number, and eases a restriction in the conda meta.yaml so I can build on py3