### PR TITLE
updates for PYME DisplayOptions and ModuleBase changes

### DIFF
--- a/nep_fitting/dsviewer_modules/sted_psf_fitting.py
+++ b/nep_fitting/dsviewer_modules/sted_psf_fitting.py
@@ -343,10 +343,10 @@ class LineProfilesOverlay:
 
             # plot individual profiles
             # fitter = profile_fitters.ensemble_fitters[fitting_module.fit_type](self._line_profile_handler)
-            fitter = rec.modules[0].fitter  # TODO - move plot_results out from class so we don't have to hack like this
+            #  fitter = rec.modules[0].fitter  # TODO - move plot_results out from class so we don't have to hack like this
             profile_dir = base_path + '/'
             os.mkdir(profile_dir)
-            fitter.plot_results(profile_dir)
+            #  fitter.plot_results(profile_dir)  # FIXME - need multi-plot output recipe module
 
             htmlfn = base_path + '.html'
             
@@ -439,10 +439,10 @@ class LineProfilesOverlay:
 
             res.to_hdf(base_path + '.hdf', tablename='profile_fits')  # table name changed to avoid conflicts with standard fit data
 
-            fitter = rec.modules[0].fitter  # TODO - move plot_results out from class so we don't have to hack like this
+            # fitter = rec.modules[0].fitter  # TODO - move plot_results out from class so we don't have to hack like this
             profile_dir = base_path + '/'
             os.mkdir(profile_dir)
-            fitter.plot_results(profile_dir)
+            # fitter.plot_results(profile_dir)
 
             htmlfn = base_path + '.html'
 

--- a/nep_fitting/dsviewer_modules/sted_psf_fitting.py
+++ b/nep_fitting/dsviewer_modules/sted_psf_fitting.py
@@ -65,7 +65,10 @@ class LineProfilesOverlay:
         This callback function is called, whenever a new line has been drawn using the selection tool
         and should be added
         """
-        trace = self._dsviewer.do.selection_trace
+        try:
+            trace = self._dsviewer.do.selection_trace
+        except AttributeError:  # PYME after 2022/11
+            trace = self._dsviewer.do.selection.trace
 
         if len(trace) > 2:
             line = LineProfile(trace[0][0], trace[0][1], trace[-1][0], trace[-1][1],
@@ -83,7 +86,10 @@ class LineProfilesOverlay:
         from nep_fitting.core import multiaxis_extraction
         if self._image.data.shape[2] == 1:
             logger.error('Cannot extract multiaxis profile from 2D data')
-        trace = self._dsviewer.do.selection_trace
+        try:
+            trace = self._dsviewer.do.selection_trace
+        except AttributeError:  # PYME after 2022/11
+            trace = self._dsviewer.do.selection.trace
 
         if len(trace) > 2:
             interp_px = self._interpolate_stack()

--- a/nep_fitting/dsviewer_modules/sted_psf_fitting.py
+++ b/nep_fitting/dsviewer_modules/sted_psf_fitting.py
@@ -43,7 +43,7 @@ class LineProfilesOverlay:
     def __init__(self, dsviewer):
         # FIXME - hard references to dsviewer etc ... will create circular references, Use plugin interface instead
         self._dsviewer = dsviewer
-        
+        self._view = dsviewer.view
         self._do = dsviewer.do
         self._image = dsviewer.image
         filename = self._image.filename

--- a/nep_fitting/recipe_modules/nep_fits.py
+++ b/nep_fitting/recipe_modules/nep_fits.py
@@ -1,7 +1,6 @@
-from PYME.recipes.base import register_module, ModuleBase, Filter
-from PYME.recipes.traits import Input, Output, Float, Enum, CStr, Bool, Int, List, DictStrStr, DictStrList, ListFloat, ListStr
+from PYME.recipes.base import register_module, ModuleBase
+from PYME.recipes.traits import Input, Output, Float, CStr, Bool, DictStrList
 
-import numpy as np
 from PYME.IO import tabular
 from PYME.IO import MetaDataHandler
 
@@ -92,14 +91,14 @@ class EnsembleFitProfiles(ModuleBase):
         handler._load_profiles_from_list(inp)
 
         fit_class = profile_fitters.ensemble_fitters[self.fit_type]
-        self.fitter = fit_class(handler)
+        fitter = fit_class(handler)
 
         if self.hold_ensemble_parameter_constant:
-            self.fitter.fit_profiles(self.ensemble_parameter_guess)
+            fitter.fit_profiles(self.ensemble_parameter_guess)
         else:
-            self.fitter.ensemble_fit(self.ensemble_parameter_guess)
+            fitter.ensemble_fit(self.ensemble_parameter_guess)
 
-        res = tabular.RecArraySource(self.fitter.results)
+        res = tabular.RecArraySource(fitter.results)
 
         # propagate metadata, if present
         res.mdh = MetaDataHandler.NestedClassMDHandler(getattr(inp, 'mdh', None))
@@ -172,11 +171,11 @@ class FitProfiles(ModuleBase):
         handler._load_profiles_from_list(inp)
 
         fit_class = profile_fitters.non_ensemble_fitters[self.fit_type]
-        self.fitter = fit_class(handler)
+        fitter = fit_class(handler)
 
-        self.fitter.fit_profiles()
+        fitter.fit_profiles()
 
-        res = tabular.RecArraySource(self.fitter.results)
+        res = tabular.RecArraySource(fitter.results)
 
         # propagate metadata, if present
         res.mdh = MetaDataHandler.NestedClassMDHandler(getattr(inp, 'mdh', None))


### PR DESCRIPTION
@David-Baddeley for plotting, we were pulling the profilefitter object out of the recipe module by attribute, which we can no longer assign. If we want to include pdf print outs of each profile fit individually, as we used to, we now have to do that through the recipe output modules. PlotOutput is close, of course, but I think it would be fairly gross to pipe N plots into the namespace and programmatically link them each with a plotoutput. Can we agree on a structure for PlotOutput to handle multiple plots? Do we need to make a `PYME.recipes.graphing.Plots` (plural) and a `PlotsOutput` to handle multiple plots?